### PR TITLE
Issue 3: add new forgot password wizard

### DIFF
--- a/app/Components/LoginComponent.php
+++ b/app/Components/LoginComponent.php
@@ -278,9 +278,9 @@ class LoginComponent {
 				// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				$principal        = isset( $_POST['principal'] ) ? wp_unslash( $_POST['principal'] ) : '';
 				$code             = isset( $_POST['code'] ) ? sanitize_text_field( wp_unslash( $_POST['code'] ) ) : '';
-				$new_password     = isset( $_POST['new_password'] ) ? wp_unslash( $_POST['new_password'] ) : '';
-				$confirm_password = isset( $_POST['confirm_password'] ) ? wp_unslash( $_POST['confirm_password'] ) : '';
-				$security_answer  = isset( $_POST['security_answer'] ) ? sanitize_text_field( wp_unslash( $_POST['security_answer'] ) ) : '';
+				$new_password     = isset( $_POST['new_pw'] ) ? wp_unslash( $_POST['new_pw'] ) : '';
+				$confirm_password = isset( $_POST['confirm_pw'] ) ? wp_unslash( $_POST['confirm_pw'] ) : '';
+				$security_answer  = isset( $_POST['sec_answer'] ) ? sanitize_text_field( wp_unslash( $_POST['sec_answer'] ) ) : '';
 				// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 				$response = $this->cyclos->forgot_password_step_change( $principal, $code, $new_password, $confirm_password, $security_answer );

--- a/app/Components/LoginComponent.php
+++ b/app/Components/LoginComponent.php
@@ -104,13 +104,16 @@ class LoginComponent {
 			set_query_var( 'cyclos_error', __( 'Something is wrong with the Cyclos server. The login form cannot be used at the moment.', 'cyclos' ) );
 			set_query_var( 'cyclos_is_forgot_password_enabled', false );
 			set_query_var( 'cyclos_is_captcha_enabled', false );
+			set_query_var( 'cyclos_forgot_password_url', '' );
 			set_query_var( 'cyclos_return_to', '' );
 		} else {
 			// Cyclos can not send us a nonce, so ignore the recommended nonce verification.
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$return_to = isset( $_GET['returnTo'] ) ? sanitize_text_field( wp_unslash( $_GET['returnTo'] ) ) : '';
+			$return_to           = isset( $_GET['returnTo'] ) ? sanitize_text_field( wp_unslash( $_GET['returnTo'] ) ) : '';
+			$forgot_password_url = $login_configuration['has_complex_forgot_password'] ? $this->conf->get_cyclos_url() . '#login%7Caccess.login.forgot-password' : '';
 			set_query_var( 'cyclos_is_forgot_password_enabled', $login_configuration['is_forgot_password_enabled'] );
 			set_query_var( 'cyclos_is_captcha_enabled', $login_configuration['is_captcha_enabled'] );
+			set_query_var( 'cyclos_forgot_password_url', $forgot_password_url );
 			set_query_var( 'cyclos_return_to', $return_to );
 		}
 

--- a/app/Configuration.php
+++ b/app/Configuration.php
@@ -106,6 +106,12 @@ class Configuration {
 				'forgot_pw_email'      => new Setting( 'login_form', __( 'Forgotten password user', 'cyclos' ), 'text', false, __( 'User', 'cyclos' ), __( 'The placeholder in the username field in the forgotten password form', 'cyclos' ) ),
 				'forgot_pw_captcha'    => new Setting( 'login_form', __( 'Forgotten password captcha', 'cyclos' ), 'text', false, __( 'Visual validation', 'cyclos' ), __( 'The placeholder in the captcha field in the forgotten password form', 'cyclos' ) ),
 				'forgot_pw_newcaptcha' => new Setting( 'login_form', __( 'Forgotten password new captcha', 'cyclos' ), 'text', false, __( 'New code', 'cyclos' ), __( 'The text for the new captcha link in the forgotten password form', 'cyclos' ) ),
+				'forgot_pw_medium'     => new Setting( 'login_form', __( 'Forgotten password send medium label', 'cyclos' ), 'text', false, __( 'Send verification code by', 'cyclos' ), __( 'The label near the (optional) send medium choice in the forgotten password form', 'cyclos' ) ),
+				'forgot_pw_mail'       => new Setting( 'login_form', __( 'Forgotten password e-mail', 'cyclos' ), 'text', false, __( 'E-mail', 'cyclos' ), __( 'The (optional) e-mail send medium choice in the forgotten password form', 'cyclos' ) ),
+				'forgot_pw_sms'        => new Setting( 'login_form', __( 'Forgotten password SMS', 'cyclos' ), 'text', false, __( 'SMS', 'cyclos' ), __( 'The (optional) SMS send medium choice in the forgotten password form', 'cyclos' ) ),
+				'forgot_pw_code'       => new Setting( 'login_form', __( 'Forgotten password code', 'cyclos' ), 'text', false, __( 'Verification code', 'cyclos' ), __( 'The placeholder in the verification code step in the forgotten password form', 'cyclos' ) ),
+				'forgot_pw_new_pw'     => new Setting( 'login_form', __( 'Forgotten password new password', 'cyclos' ), 'text', false, __( 'New password', 'cyclos' ), __( 'The placeholder in the new password field in the forgotten password form', 'cyclos' ) ),
+				'forgot_pw_confirm_pw' => new Setting( 'login_form', __( 'Forgotten password confirm password', 'cyclos' ), 'text', false, __( 'Confirm new password', 'cyclos' ), __( 'The placeholder in the confirmation field of the new password in the forgotten password form', 'cyclos' ) ),
 				'forgot_pw_submit'     => new Setting( 'login_form', __( 'Forgotten password submit', 'cyclos' ), 'text', false, __( 'Submit', 'cyclos' ), __( 'The text on the submit button in the forgotten password form', 'cyclos' ) ),
 				'forgot_pw_cancel'     => new Setting( 'login_form', __( 'Forgotten password cancel', 'cyclos' ), 'text', false, __( 'Cancel', 'cyclos' ), __( 'The text for the cancel link in the forgotten password form', 'cyclos' ) ),
 			);
@@ -356,6 +362,12 @@ class Configuration {
 			'forgot_newcaptcha' => $this->get_setting( 'forgot_pw_newcaptcha' ),
 			'forgot_submit'     => $this->get_setting( 'forgot_pw_submit' ),
 			'forgot_cancel'     => $this->get_setting( 'forgot_pw_cancel' ),
+			'forgot_medium'     => $this->get_setting( 'forgot_pw_medium' ),
+			'forgot_email'      => $this->get_setting( 'forgot_pw_mail' ),
+			'forgot_sms'        => $this->get_setting( 'forgot_pw_sms' ),
+			'forgot_code'       => $this->get_setting( 'forgot_pw_code' ),
+			'forgot_new_pw'     => $this->get_setting( 'forgot_pw_new_pw' ),
+			'forgot_confirm_pw' => $this->get_setting( 'forgot_pw_confirm_pw' ),
 		);
 	}
 

--- a/app/Configuration.php
+++ b/app/Configuration.php
@@ -110,6 +110,7 @@ class Configuration {
 				'forgot_pw_mail'       => new Setting( 'login_form', __( 'Forgotten password e-mail', 'cyclos' ), 'text', false, __( 'E-mail', 'cyclos' ), __( 'The (optional) e-mail send medium choice in the forgotten password form', 'cyclos' ) ),
 				'forgot_pw_sms'        => new Setting( 'login_form', __( 'Forgotten password SMS', 'cyclos' ), 'text', false, __( 'SMS', 'cyclos' ), __( 'The (optional) SMS send medium choice in the forgotten password form', 'cyclos' ) ),
 				'forgot_pw_code'       => new Setting( 'login_form', __( 'Forgotten password code', 'cyclos' ), 'text', false, __( 'Verification code', 'cyclos' ), __( 'The placeholder in the verification code step in the forgotten password form', 'cyclos' ) ),
+				'forgot_pw_sec_answer' => new Setting( 'login_form', __( 'Forgotten password security answer', 'cyclos' ), 'text', false, __( 'Your answer', 'cyclos' ), __( 'The placeholder in the answer to the security question field in the forgotten password form', 'cyclos' ) ),
 				'forgot_pw_new_pw'     => new Setting( 'login_form', __( 'Forgotten password new password', 'cyclos' ), 'text', false, __( 'New password', 'cyclos' ), __( 'The placeholder in the new password field in the forgotten password form', 'cyclos' ) ),
 				'forgot_pw_confirm_pw' => new Setting( 'login_form', __( 'Forgotten password confirm password', 'cyclos' ), 'text', false, __( 'Confirm new password', 'cyclos' ), __( 'The placeholder in the confirmation field of the new password in the forgotten password form', 'cyclos' ) ),
 				'forgot_pw_submit'     => new Setting( 'login_form', __( 'Forgotten password submit', 'cyclos' ), 'text', false, __( 'Submit', 'cyclos' ), __( 'The text on the submit button in the forgotten password form', 'cyclos' ) ),
@@ -366,6 +367,7 @@ class Configuration {
 			'forgot_email'      => $this->get_setting( 'forgot_pw_mail' ),
 			'forgot_sms'        => $this->get_setting( 'forgot_pw_sms' ),
 			'forgot_code'       => $this->get_setting( 'forgot_pw_code' ),
+			'forgot_security'   => $this->get_setting( 'forgot_pw_sec_answer' ),
 			'forgot_new_pw'     => $this->get_setting( 'forgot_pw_new_pw' ),
 			'forgot_confirm_pw' => $this->get_setting( 'forgot_pw_confirm_pw' ),
 		);

--- a/app/Services/Cyclos4/AuthService.php
+++ b/app/Services/Cyclos4/AuthService.php
@@ -32,7 +32,8 @@ class AuthService extends Service {
 		$this->method = 'GET';
 		$this->route  = '/auth/data-for-login';
 		$this->authenticate_as_guest();
-		// Note: we don't need to specify a channel, because the information we need from data-for-login does not depend on the channel.
+		// Note: In this case we must specify the channel to be 'Main', because the information we need from data-for-login might depend on the channel.
+		$this->use_explicit_main_channel();
 		return $this->run();
 	}
 

--- a/app/Services/Cyclos4/AuthService.php
+++ b/app/Services/Cyclos4/AuthService.php
@@ -43,9 +43,10 @@ class AuthService extends Service {
 	 * @param string $principal         The principal (i.e. username, e-mail, ..) to identify the user with.
 	 * @param string $captcha_id        The ID of the captcha challenge.
 	 * @param string $captcha_response  The response for the captcha challenge.
+	 * @param string $send_medium       (Optional) The medium (email/sms) to use for sending the verification code to the visitor.
 	 * @return object|\WP_Error The body from the Cyclos server response or a WP_Error object on failure.
 	 */
-	public function forgotten_password_request( string $principal, string $captcha_id, string $captcha_response ) {
+	public function forgotten_password_request( string $principal, string $captcha_id, string $captcha_response, string $send_medium = null ) {
 		$this->method = 'POST';
 		$this->route  = '/auth/forgotten-password/request';
 		$data         = array(
@@ -55,6 +56,53 @@ class AuthService extends Service {
 				'response'  => $captcha_response,
 			),
 		);
+		if ( $send_medium ) {
+			$data['sendMedium'] = $send_medium;
+		}
+		return $this->run( $data );
+	}
+
+	/**
+	 * Returns configuration data used to change a forgotten password after the initial request.
+	 *
+	 * @param string $principal         The principal (i.e. username, e-mail, ..) to identify the user with.
+	 * @param string $code              The verification code which was sent to the user.
+	 *
+	 * @return object|\WP_Error The body from the Cyclos server response or a WP_Error object on failure.
+	 */
+	public function forgotten_password_data_for_change( string $principal, string $code ) {
+		$this->method = 'GET';
+		$this->route  = '/auth/forgotten-password/data-for-change';
+		$this->route .= '?user=' . $principal . '&code=' . $code;
+		$this->authenticate_as_guest();
+		return $this->run();
+	}
+
+	/**
+	 * Changes the forgotten password after the user has completed the request.
+	 *
+	 * @param string $principal         The principal (i.e. username, e-mail, ..) to identify the user with.
+	 * @param string $code              The verification code which was sent to the user.
+	 * @param string $new_password      The new password.
+	 * @param string $confirm_password  The new password again as a way of confirmation.
+	 * @param string $security_answer   (Optional) The answer to the security question if one was used.
+	 *
+	 * @return object|\WP_Error The body from the Cyclos server response or a WP_Error object on failure.
+	 */
+	public function forgotten_password( string $principal, string $code, string $new_password, string $confirm_password, string $security_answer = null ) {
+		$this->method = 'POST';
+		$this->route  = '/auth/forgotten-password';
+		$data         = array(
+			'user'                    => $principal,
+			'code'                    => $code,
+			'newPassword'             => $new_password,
+			'newPasswordConfirmation' => $confirm_password,
+			'checkConfirmation'       => true, // This is needed to have Cyclos check the confirmation password value.
+		);
+		if ( $security_answer ) {
+			$data['securityAnswer'] = $security_answer;
+		}
+		$this->authenticate_as_guest();
 		return $this->run( $data );
 	}
 

--- a/app/Services/Cyclos4/Service.php
+++ b/app/Services/Cyclos4/Service.php
@@ -43,6 +43,13 @@ class Service {
 	protected $authentication;
 
 	/**
+	 * The channel to use in the request. Defaults to empty, to follow the default channel per Cyclos route.
+	 *
+	 * @var array $channel The channel.
+	 */
+	protected $channel = array();
+
+	/**
 	 * The configuration with the plugin settings.
 	 *
 	 * @var Configuration $conf The configuration.
@@ -93,6 +100,15 @@ class Service {
 	}
 
 	/**
+	 * Configure the channel used in the request to be Main.
+	 */
+	protected function use_explicit_main_channel() {
+		$this->channel = array(
+			'Channel' => 'main',
+		);
+	}
+
+	/**
 	 * Execute a request to the Cyclos API.
 	 *
 	 * @param array $data      (Optional) The data to post to the Cyclos API.
@@ -106,7 +122,8 @@ class Service {
 				array(
 					'Content-Type' => 'application/json',
 				),
-				$this->authentication
+				$this->authentication,
+				$this->channel
 			),
 		);
 

--- a/app/Services/CyclosAPI.php
+++ b/app/Services/CyclosAPI.php
@@ -176,9 +176,8 @@ class CyclosAPI {
 			return array();
 		}
 
-		// If we have no error, return whether the forgotPasswordMediums information is filled. If disabled, this is an empty array.
-		// If the captcha is enabled, the forgotPasswordCaptchaProvider is not null.
-		// From Cyclos 4.13 on, the forgot password construction is more complex, so we will just redirect the visitor to Cyclos.
+		// If we have no error, return an array with all relevant login configuration information.
+		// From Cyclos 4.13 on, the forgot password construction is more complex, requiring a small wizard in our login template.
 		// We use the existence of the identityProviders property that was added in 4.13 to indicate this.
 		// Note: the variables in the json we receive from Cyclos. So disable the coding standard for snake case on this line.
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
@@ -186,6 +185,7 @@ class CyclosAPI {
 			'is_forgot_password_enabled'  => ! empty( $cyclos_response->forgotPasswordMediums ),
 			'is_captcha_enabled'          => isset( $cyclos_response->forgotPasswordCaptchaProvider ),
 			'has_complex_forgot_password' => isset( $cyclos_response->identityProviders ),
+			'forgot_password_mediums'     => $cyclos_response->forgotPasswordMediums,
 		);
 		// phpcs:enable
 	}
@@ -237,6 +237,7 @@ class CyclosAPI {
 
 	/**
 	 * Method to let a user request a forgotten password reset.
+	 * This is only used on Cyclos versions before 4.13. From 4.13 on, the forgot password is handled via a wizard.
 	 *
 	 * @param string $principal        The principal (i.e. username, e-mail, ..) to identify the user with.
 	 * @param string $captcha_id       The ID of the captcha challenge.
@@ -256,6 +257,105 @@ class CyclosAPI {
 			$error_message = $this->handle_error( $cyclos_response );
 		} else {
 			$success_message = __( 'You will receive an e-mail shortly with your user identification and instructions on how to reset your password', 'cyclos' );
+		}
+
+		return array(
+			'successMessage' => $success_message,
+			'errorMessage'   => $error_message,
+		);
+	}
+
+	/**
+	 * Method to let a user request a forgotten password reset using the new Cyclos mechanism, requiring a small wizard with steps.
+	 * This method handles step 1 of the wizard.
+	 *
+	 * @param string $principal        The principal (i.e. username, e-mail, ..) to identify the user with.
+	 * @param string $captcha_id       The ID of the captcha challenge.
+	 * @param string $captcha_response The response for the captcha challenge.
+	 * @param string $send_medium      The medium (email/sms) to use for sending the verification code to the visitor.
+	 * @return array                   Array containing a successmessage or an errormessage on failure.
+	 */
+	public function forgot_password_step_request( string $principal, string $captcha_id, string $captcha_response, string $send_medium ) {
+		$success_message = '';
+		$error_message   = '';
+
+		// Use the authentication service to request the password reset.
+		$cyclos_service  = new Cyclos4\AuthService( $this->conf );
+		$cyclos_response = $cyclos_service->forgotten_password_request( $principal, $captcha_id, $captcha_response, $send_medium );
+
+		// Set the error or success message, depending on whether we have an error situation or not.
+		if ( is_wp_error( $cyclos_response ) ) {
+			$error_message = $this->handle_error( $cyclos_response );
+		} else {
+			$sent_to = $cyclos_response->sentTo; // phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			if ( is_array( $sent_to ) && count( $sent_to ) > 0 ) {
+				$success_message = __( 'A verification code has been sent to ', 'cyclos' ) . $sent_to[0];
+			} else {
+				$error_message = __( 'Something went wrong while trying to send you the verification code. Please contact the administration.', 'cyclos' );
+			}
+		}
+
+		return array(
+			'successMessage' => $success_message,
+			'errorMessage'   => $error_message,
+		);
+	}
+
+	/**
+	 * Method to handle the verification code step in a user request for a forgotten password reset.
+	 * This method handles step 2 of the wizard.
+	 *
+	 * @param string $principal        The principal (i.e. username, e-mail, ..) to identify the user with.
+	 * @param string $code             The verification code which was sent to the user.
+	 * @return array                   Array containing the security question (or empty string if not enabled in Cyclos) or an errormessage on failure.
+	 */
+	public function forgot_password_step_code( string $principal, string $code ) {
+		$error_message = '';
+
+		// Use the authentication service to request the password reset code step.
+		$cyclos_service  = new Cyclos4\AuthService( $this->conf );
+		$cyclos_response = $cyclos_service->forgotten_password_data_for_change( $principal, $code );
+
+		// Set the error if we have an error situation.
+		if ( is_wp_error( $cyclos_response ) ) {
+			$error_message = $this->handle_error( $cyclos_response );
+		} else {
+			// Check the password type. It must be 'manual'.
+			if ( 'manual' !== $cyclos_response->passwordType->mode ) {
+				$error_message = __( 'You can not change this password manually. Please contact the administration.', 'cyclos' );
+			}
+		}
+
+		return array(
+			'securityQuestion' => $cyclos_response->securityQuestion ?? '',
+			'errorMessage'     => $error_message,
+		);
+	}
+
+	/**
+	 * Method to handle the change step in a user request for a forgotten password reset.
+	 * This method handles step 3 of the wizard.
+	 *
+	 * @param string $principal        The principal (i.e. username, e-mail, ..) to identify the user with.
+	 * @param string $code             The verification code which was sent to the user.
+	 * @param string $new_password     The new password.
+	 * @param string $confirm_password The new password again as a way of confirmation.
+	 * @param string $security_answer  (Optional) The answer to the security question if one was used.
+	 * @return array                   Array containing a successmessage or an errormessage on failure.
+	 */
+	public function forgot_password_step_change( string $principal, string $code, string $new_password, string $confirm_password, string $security_answer = null ) {
+		$success_message = '';
+		$error_message   = '';
+
+		// Use the authentication service to reset the password.
+		$cyclos_service  = new Cyclos4\AuthService( $this->conf );
+		$cyclos_response = $cyclos_service->forgotten_password( $principal, $code, $new_password, $confirm_password, $security_answer );
+
+		// Set the error message, depending on whether we have an error situation or not.
+		if ( is_wp_error( $cyclos_response ) ) {
+			$error_message = $this->handle_error( $cyclos_response );
+		} else {
+			$success_message = __( 'Your password has been reset', 'cyclos' );
 		}
 
 		return array(
@@ -312,6 +412,9 @@ class CyclosAPI {
 				'pw-pending'                    => __( 'Your password is pending', 'cyclos' ),
 				'pw-reset'                      => __( 'Your password was reset', 'cyclos' ),
 				'pw-temporarilyBlocked'         => __( 'Your password is temporarily blocked by exceeding invalid login attempts', 'cyclos' ),
+				'keyInvalidated'                => __( 'The code received on the forgotten password reset request was invalidated because the maximum number of tries was reached', 'cyclos' ),
+				'invalidSecurityAnswer'         => __( 'The answer for the security question was incorrect', 'cyclos' ),
+				'unexpected'                    => __( 'An unexpected error has occurred', 'cyclos' ),
 			);
 
 			// Check the error information from Cyclos. The message contains the HTTP status code, the data contains the response.
@@ -379,6 +482,17 @@ class CyclosAPI {
 					// The response contains a "kind" property.
 					$code = $response->kind ?? '';
 
+					// Handle security question errors differentely.
+					if ( 'forgottenPassword' === $code ) {
+						// Check the code property in the response.
+						$forgotten_pw_error = $response->code ?? 'unexpected';
+						if ( 'invalidSecurityAnswer' === $forgotten_pw_error ) {
+							// Check if the key/code for requesting a password reset is invalid due to reaching the max nr of tries.
+							$is_invalid_key = $response->keyInvalidated ?? false;
+						}
+						// Use the proper code to look up the message in our error_codes table above.
+						$code = $is_invalid_key ? 'keyInvalidated' : $forgotten_pw_error;
+					}
 					// Look up the corresponding message in our error codes table.
 					$message = $error_codes[ $code ] ?? '';
 					break;

--- a/app/Services/CyclosAPI.php
+++ b/app/Services/CyclosAPI.php
@@ -181,7 +181,7 @@ class CyclosAPI {
 		// We use the existence of the identityProviders property that was added in 4.13 to indicate this.
 		// Note: the variables in the json we receive from Cyclos. So disable the coding standard for snake case on this line.
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		// The password type must be manual and there must be medium to reset it. Otherwise we can not do a forgotten password request.
+		// The password type must be manual and there must be a medium to reset it. Otherwise we can not do a forgotten password request.
 		$login_pw_mode        = $cyclos_response->loginPasswordInput->mode ?? '';
 		$is_forgot_pw_allowed = ( 'manual' === $login_pw_mode ) && ! empty( $cyclos_response->forgotPasswordMediums );
 		return array(

--- a/app/Services/CyclosAPI.php
+++ b/app/Services/CyclosAPI.php
@@ -326,8 +326,15 @@ class CyclosAPI {
 			}
 		}
 
+		// Fill the security question.
+		$sec_question = '';
+		if ( $cyclos_response->securityQuestion ) {
+			$sec_question = __( 'Please answer your security question', 'cyclos' ) . ': ' . $cyclos_response->securityQuestion;
+		}
+
 		return array(
-			'securityQuestion' => $cyclos_response->securityQuestion ?? '',
+			'passwordHint'     => $cyclos_response->passwordType->description ?? '',
+			'securityQuestion' => $sec_question,
 			'errorMessage'     => $error_message,
 		);
 	}

--- a/app/Services/CyclosAPI.php
+++ b/app/Services/CyclosAPI.php
@@ -163,6 +163,7 @@ class CyclosAPI {
 	 * @return array {
 	 *     @type boolean $is_forgot_password_enabled  Whether the forgotten password functionality is enabled in Cyclos or not.
 	 *     @type boolean $is_captcha_enabled          Whether the captcha functionality is enabled in Cyclos or not.
+	 *     @type boolean $has_complex_forgot_password Whether the current Cyclos version uses a more complex forgot password wizard.
 	 * }
 	 */
 	public function login_configuration() {
@@ -177,11 +178,14 @@ class CyclosAPI {
 
 		// If we have no error, return whether the forgotPasswordMediums information is filled. If disabled, this is an empty array.
 		// If the captcha is enabled, the forgotPasswordCaptchaProvider is not null.
+		// From Cyclos 4.13 on, the forgot password construction is more complex, so we will just redirect the visitor to Cyclos.
+		// We use the existence of the identityProviders property that was added in 4.13 to indicate this.
 		// Note: the variables in the json we receive from Cyclos. So disable the coding standard for snake case on this line.
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		return array(
-			'is_forgot_password_enabled' => ! empty( $cyclos_response->forgotPasswordMediums ),
-			'is_captcha_enabled'         => isset( $cyclos_response->forgotPasswordCaptchaProvider ),
+			'is_forgot_password_enabled'  => ! empty( $cyclos_response->forgotPasswordMediums ),
+			'is_captcha_enabled'          => isset( $cyclos_response->forgotPasswordCaptchaProvider ),
+			'has_complex_forgot_password' => isset( $cyclos_response->identityProviders ),
 		);
 		// phpcs:enable
 	}

--- a/app/Services/CyclosAPI.php
+++ b/app/Services/CyclosAPI.php
@@ -158,16 +158,17 @@ class CyclosAPI {
 	}
 
 	/**
-	 * Returns an array indicating whether the forgot password functionality and the captcha are enabled in Cyclos.
+	 * Returns an array with information needed for the forgot password functionality.
 	 *
 	 * @return array {
 	 *     @type boolean $is_forgot_password_enabled  Whether the forgotten password functionality is enabled in Cyclos or not.
 	 *     @type boolean $is_captcha_enabled          Whether the captcha functionality is enabled in Cyclos or not.
 	 *     @type boolean $has_complex_forgot_password Whether the current Cyclos version uses a more complex forgot password wizard.
+	 *     @type Array $forgot_password_mediums       List of mediums the user can choose to receive the forgot password verification code.
 	 * }
 	 */
 	public function login_configuration() {
-		// Use the AuthService to get the data for login, containing information on the forgotPasswordMediums if available.
+		// Use the AuthService to get the data for login, containing information for the forgot password functionality.
 		$cyclos_service  = new Cyclos4\AuthService( $this->conf );
 		$cyclos_response = $cyclos_service->get_data_for_login();
 
@@ -179,7 +180,7 @@ class CyclosAPI {
 		// If we have no error, return an array with all relevant login configuration information.
 		// From Cyclos 4.13 on, the forgot password construction is more complex, requiring a small wizard in our login template.
 		// We use the existence of the identityProviders property that was added in 4.13 to indicate this.
-		// Note: the variables in the json we receive from Cyclos. So disable the coding standard for snake case on this line.
+		// Note: the variables in the json we receive from Cyclos. So disable the coding standard for snake case on the following lines.
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		// The password type must be manual and there must be a medium to reset it. Otherwise we can not do a forgotten password request.
 		$login_pw_mode        = $cyclos_response->loginPasswordInput->mode ?? '';

--- a/app/Services/CyclosAPI.php
+++ b/app/Services/CyclosAPI.php
@@ -181,8 +181,11 @@ class CyclosAPI {
 		// We use the existence of the identityProviders property that was added in 4.13 to indicate this.
 		// Note: the variables in the json we receive from Cyclos. So disable the coding standard for snake case on this line.
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		// The password type must be manual and there must be medium to reset it. Otherwise we can not do a forgotten password request.
+		$login_pw_mode        = $cyclos_response->loginPasswordInput->mode ?? '';
+		$is_forgot_pw_allowed = ( 'manual' === $login_pw_mode ) && ! empty( $cyclos_response->forgotPasswordMediums );
 		return array(
-			'is_forgot_password_enabled'  => ! empty( $cyclos_response->forgotPasswordMediums ),
+			'is_forgot_password_enabled'  => $is_forgot_pw_allowed,
 			'is_captcha_enabled'          => isset( $cyclos_response->forgotPasswordCaptchaProvider ),
 			'has_complex_forgot_password' => isset( $cyclos_response->identityProviders ),
 			'forgot_password_mediums'     => $cyclos_response->forgotPasswordMediums,
@@ -319,11 +322,6 @@ class CyclosAPI {
 		// Set the error if we have an error situation.
 		if ( is_wp_error( $cyclos_response ) ) {
 			$error_message = $this->handle_error( $cyclos_response );
-		} else {
-			// Check the password type. It must be 'manual'.
-			if ( 'manual' !== $cyclos_response->passwordType->mode ) {
-				$error_message = __( 'You can not change this password manually. Please contact the administration.', 'cyclos' );
-			}
 		}
 
 		// Fill the security question.

--- a/css/login.css
+++ b/css/login.css
@@ -6,6 +6,7 @@
 .cyclos-form-box input[type="password"],
 .cyclos-form-box input[type="button"],
 .cyclos-form-box input[type="submit"],
+.cyclos-form-box select,
 .cyclos-form-box a,
 .cyclos-form-box p,
 .cyclos-form-box label,
@@ -21,6 +22,7 @@
 .cyclos-form-box input[type="text"],
 .cyclos-form-box input[type="password"],
 .cyclos-form-box input[type="button"],
+.cyclos-form-box select,
 .cyclos-form-box input[type="submit"] {
 	line-height: 1;
 	color: #5f5f5f;

--- a/css/login.css
+++ b/css/login.css
@@ -7,6 +7,8 @@
 .cyclos-form-box input[type="button"],
 .cyclos-form-box input[type="submit"],
 .cyclos-form-box a,
+.cyclos-form-box p,
+.cyclos-form-box label,
 .cyclos-form-box .notice {
 	font-family: Helvetica, Arial, sans-serif;
 	font-size: 14px;

--- a/js/src/cyclos_login.js
+++ b/js/src/cyclos_login.js
@@ -200,6 +200,14 @@ jQuery( document ).ready( function ( $ ) {
 								response.securityQuestion
 							);
 						}
+
+						// Show the password hint (if available).
+						if ( response.passwordHint ) {
+							showPasswordHint(
+								forgotForm,
+								response.passwordHint
+							);
+						}
 						break;
 					case 'change':
 					case 'simple':
@@ -261,6 +269,12 @@ jQuery( document ).ready( function ( $ ) {
 		);
 		securityQuestionP.find( '.cyclos-question' ).text( question );
 		securityQuestionP.show();
+	}
+
+	function showPasswordHint( forgotForm, hint ) {
+		const passwordHintP = $( forgotForm ).find( '.cyclos-password-hint' );
+		passwordHintP.text( hint );
+		passwordHintP.show();
 	}
 
 	function resetForgotForm( forgotForm ) {

--- a/js/src/cyclos_login.js
+++ b/js/src/cyclos_login.js
@@ -113,12 +113,163 @@ jQuery( document ).ready( function ( $ ) {
 	// Handle submit on the forgot password form.
 	$( '.cyclos-forgotpassword-form' ).submit( function ( event ) {
 		event.preventDefault();
-		cyclosLoginObj = cyclosLoginObj || {};
+
 		// Find the form this link belongs to. And from there, find the other elements relative to this form.
 		const forgotForm = this;
 		const box = $( forgotForm ).parents( '.cyclos-form-box' );
 		const loginForm = $( box ).find( '.cyclos-login-form' );
 		const notice = $( box ).find( '.notice' );
+
+		// Determine which version of the forgot password we should use.
+		if ( $( forgotForm ).find( '.cyclos-wizard-step' ) ) {
+			forgotPWRequestWizard( forgotForm, loginForm, notice );
+		} else {
+			forgotPWRequestSimple( forgotForm, loginForm, notice );
+		}
+	} );
+
+	// The forgotten password wizard, using newer Cyclos versions (4.13 or newer).
+	function forgotPWRequestWizard( forgotForm, loginForm, notice ) {
+		cyclosLoginObj = cyclosLoginObj || {};
+		const data = {
+			_ajax_nonce: cyclosLoginObj.id,
+			action: 'cyclos_forgot_password_wizard',
+		};
+		$( notice ).hide();
+
+		// Find the step we are in and add the relevant information to the data we will post.
+		const stepField = $( forgotForm ).find(
+			'input[name="cyclos-wizard-step"]'
+		);
+		const step = stepField?.val();
+
+		// Always pass the step and the principal.
+		data.step = step;
+		data.principal = $( forgotForm )
+			.find( 'input[name="principal"]' )
+			?.val()
+			.trim();
+
+		// For each step, put the data we need to post in our data object.
+		switch ( step ) {
+			case 'request':
+				// Only do captcha things when the captcha field is there; it might not be when captcha is disabled in Cyclos.
+				if ( $( forgotForm ).find( '.cyclos-captcha' ).length ) {
+					data.captcha_id = $( forgotForm ).data( 'captchaID' );
+					data.captcha_response = $( forgotForm )
+						.find( 'input[name="captcha"]' )
+						.val()
+						.trim();
+				}
+				data.send_medium = $( forgotForm )
+					.find( 'input[name="send-medium"]' )
+					?.val();
+				break;
+			case 'code':
+				data.code = $( forgotForm ).find( 'input[name="code"]' )?.val();
+				break;
+			case 'change':
+				data.code = $( forgotForm ).find( 'input[name="code"]' )?.val();
+				// Only pass the answer on the security question if it is visible.
+				const securityQuestionP = $( forgotForm ).find(
+					'.cyclos-security-question'
+				);
+				if ( securityQuestionP?.is( ':visible' ) ) {
+					data.security_answer = $( forgotForm )
+						.find( 'input[name="security-answer"]' )
+						?.val();
+				}
+				data.new_password = $( forgotForm )
+					.find( 'input[name="new-password"]' )
+					?.val();
+				data.confirm_password = $( forgotForm )
+					.find( 'input[name="confirm-password"]' )
+					?.val();
+				break;
+		}
+
+		// Post the data to WP.
+		$.post( cyclosLoginObj.ajax_url, data )
+			.done( function ( response ) {
+				response = response || {};
+				if ( response.errorMessage ) {
+					showForgotPWError(
+						notice,
+						forgotForm,
+						response.errorMessage
+					);
+					return;
+				}
+				switch ( step ) {
+					case 'request':
+						// Go to the next step.
+						stepField.val( 'code' );
+						$( forgotForm )
+							.find( '.cyclos-wizard-step-request' )
+							?.hide();
+						$( forgotForm )
+							.find( '.cyclos-wizard-step-code' )
+							?.show();
+						$( notice )
+							.html( `${ response.successMessage }.` )
+							.show();
+						break;
+					case 'code':
+						// Go to the next step.
+						stepField.val( 'change' );
+						$( forgotForm )
+							.find( '.cyclos-wizard-step-code' )
+							?.hide();
+						$( forgotForm )
+							.find( '.cyclos-wizard-step-change' )
+							?.show();
+						if ( response.securityQuestion ) {
+							// Show the security question.
+							const securityQuestionP = $( forgotForm ).find(
+								'.cyclos-security-question'
+							);
+							securityQuestionP
+								.find( '.cyclos-question' )
+								.text( `${ response.securityQuestion }` );
+							securityQuestionP.show();
+						}
+						break;
+					case 'change':
+						// We just completed the last step.
+						// Empty the fields in the forgot pw form steps and reset the hidden step field to the first step.
+						$( forgotForm ).hide();
+						$( forgotForm )
+							.find( 'div input[type!="hidden"]' ) // The sendMedium field may be hidden, if so don't empty it.
+							.val( '' );
+						$( forgotForm ).find( 'div' ).hide();
+						$( forgotForm )
+							.find( '.cyclos-wizard-step-request' )
+							?.show();
+						stepField.val( 'request' );
+						newCaptcha( forgotForm, notice );
+						// Show the success message and show the login form again.
+						$( notice )
+							.html( `${ response.successMessage }.` )
+							.show();
+						$( loginForm ).show();
+						break;
+					default:
+						// There can not be another step than the steps we handled above. So this is an error.
+						showForgotPWError(
+							notice,
+							forgotForm,
+							loginFormSetupMessage
+						);
+				}
+			} )
+			.fail( function () {
+				showForgotPWError( notice, forgotForm, loginFormSetupMessage );
+			} );
+	}
+
+	// The simple request for forgotten passwords, using older Cyclos versions (4.12 or older).
+	function forgotPWRequestSimple( forgotForm, loginForm, notice ) {
+		cyclosLoginObj = cyclosLoginObj || {};
 		const data = {
 			_ajax_nonce: cyclosLoginObj.id,
 			action: 'cyclos_forgot_password',
@@ -160,7 +311,13 @@ jQuery( document ).ready( function ( $ ) {
 				// Remove focus from the submit button.
 				$( forgotForm ).find( 'input[type="submit"]' ).blur();
 			} );
-	} );
+	}
+
+	function showForgotPWError( notice, forgotForm, msg ) {
+		$( notice ).html( `${ msg }` ).show();
+		// Remove focus from the submit button.
+		$( forgotForm ).find( 'input[type="submit"]' ).blur();
+	}
 
 	// Generates a new captcha image and puts it on the captcha element of the given form.
 	// The ID of the captcha is stored on the form as a jQuery data value.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"lint:pkg-json": "wp-scripts lint-pkg-json",
 		"lint:php": "composer wpcs:check",
 		"start": "wp-scripts start",
+		"start:login": "wp-scripts start js/src/cyclos_login.js --output-path=js/dist",
 		"autoload:dev": "composer dump-autoload"
 	}
 }

--- a/templates/login-form.php
+++ b/templates/login-form.php
@@ -77,6 +77,7 @@
 							</label>
 						</p>
 
+						<p class='cyclos-password-hint' style='display:none'></p>
 						<p><input placeholder="<?php cyclos_loginform_label( 'forgot_new_pw' ); ?>" name='new-password' type='password'></p>
 						<p><input placeholder="<?php cyclos_loginform_label( 'forgot_confirm_pw' ); ?>" name='confirm-password' type='password'></p>
 					</div>

--- a/templates/login-form.php
+++ b/templates/login-form.php
@@ -8,7 +8,8 @@
  * Available variables:
  * $cyclos_is_forgot_password_enabled indicates whether the functionality to recover a forgotten password is enabled in Cyclos.
  * $cyclos_is_captcha_enabled indicates whether Cyclos requires a captcha to request a forgotten password reset.
- * $cyclos_forgot_password_url contains the Cyclos URL to request a forgotten password reset, or empty string if the plugin should handle this (for older Cyclos versions).
+ * $cyclos_use_forgot_password_wizard whether we should handle forgotten password requests via a wizard, or via a simple request (for older Cyclos versions).
+ * $cyclos_forgot_password_mediums contains an array of the mediums the user can choose to receive the confirmation key or code. Empty when forgot password is disabled.
  * $cyclos_return_to contains the Cyclos request parameter indicating where to go within Cyclos after logging in. Can be empty.
  * $cyclos_error contains the error message in case of a severe error with the Cyclos server, for example if the server can not be reached. Can be empty.
  *
@@ -22,20 +23,84 @@
 
 	<?php if ( empty( $cyclos_error ) ) : ?>
 
-		<?php // For older Cyclos versions, we can handle the forgot password request here. Indicated by an empty forgot-password-url. ?>
-		<?php if ( $cyclos_is_forgot_password_enabled && empty( $cyclos_forgot_password_url ) ) : ?>
+		<?php if ( $cyclos_is_forgot_password_enabled ) : ?>
+
 			<form class='cyclos-forgotpassword-form' action='#' method='post' style='display:none'>
-				<p><input placeholder="<?php cyclos_loginform_label( 'forgot_principal' ); ?>" name='principal' type='text' autocomplete="username" required></p>
-				<?php if ( $cyclos_is_captcha_enabled ) : ?>
-					<p class="cyclos-line">
-						<input placeholder="<?php cyclos_loginform_label( 'forgot_captcha' ); ?>" name='captcha' type='text' required>
-						<a class="cyclos-newcaptcha" href='#'><?php cyclos_loginform_label( 'forgot_newcaptcha' ); ?></a>
-					</p>
-					<p><img class="cyclos-captcha" alt='captcha' style='display:none'></p>
+
+				<?php if ( $cyclos_use_forgot_password_wizard ) : ?>
+					<input type='hidden' name='cyclos-wizard-step' value='request'>
+
+					<?php // Show the forgot password wizard, containing three steps. ?>
+
+					<div class='cyclos-wizard-step-request'>
+
+						<?php // 1. Request step: principal, captcha, sendMedium. ?>
+
+						<p><input placeholder="<?php cyclos_loginform_label( 'forgot_principal' ); ?>" name='principal' type='text' autocomplete="username"></p>
+
+						<?php if ( $cyclos_is_captcha_enabled ) : ?>
+							<p class="cyclos-line">
+								<input placeholder="<?php cyclos_loginform_label( 'forgot_captcha' ); ?>" name='captcha' type='text'>
+								<a class="cyclos-newcaptcha" href='#'><?php cyclos_loginform_label( 'forgot_newcaptcha' ); ?></a>
+							</p>
+							<p><img class="cyclos-captcha" alt='captcha' style='display:none'></p>
+						<?php endif; ?>
+
+						<?php if ( count( $cyclos_forgot_password_mediums ) > 1 ) : ?>
+							<label><?php cyclos_loginform_label( 'forgot_medium' ); ?>:
+								<select name='send-medium'>
+									<option value='email'><?php cyclos_loginform_label( 'forgot_email' ); ?></option>
+									<option value='sms'><?php cyclos_loginform_label( 'forgot_sms' ); ?></option>
+								</select>
+							</label>
+						<?php else : ?>
+							<input name='send-medium' value='<?php echo esc_attr( $cyclos_forgot_password_mediums[0] ); ?>' type='hidden'>
+						<?php endif; ?>
+
+					</div>
+
+					<div class='cyclos-wizard-step-code' style='display:none'>
+
+						<?php // 2. Code step: principal (from request step), verification code. ?>
+
+						<p><input placeholder="<?php cyclos_loginform_label( 'forgot_code' ); ?>" name='code' type='text'></p>
+
+					</div>
+
+					<div class='cyclos-wizard-step-change' style='display:none'>
+
+						<?php // 3. Change step: principal (from request step), verification code (from code step), security question, new password + confirmation. ?>
+
+						<p class='cyclos-security-question' style='display:none'>
+							<label><span class='cyclos-question'></span>
+								<input placeholder="<?php cyclos_loginform_label( 'forgot_security' ); ?>" name='security-answer' type='text'>
+							</label>
+						</p>
+
+						<p><input placeholder="<?php cyclos_loginform_label( 'forgot_new_pw' ); ?>" name='new-password' type='password'></p>
+						<p><input placeholder="<?php cyclos_loginform_label( 'forgot_confirm_pw' ); ?>" name='confirm-password' type='password'></p>
+					</div>
+
+				<?php else : ?>
+
+					<?php // Show the simple forgot password form elements. ?>
+
+					<p><input placeholder="<?php cyclos_loginform_label( 'forgot_principal' ); ?>" name='principal' type='text' autocomplete="username" required></p>
+					<?php if ( $cyclos_is_captcha_enabled ) : ?>
+						<p class="cyclos-line">
+							<input placeholder="<?php cyclos_loginform_label( 'forgot_captcha' ); ?>" name='captcha' type='text' required>
+							<a class="cyclos-newcaptcha" href='#'><?php cyclos_loginform_label( 'forgot_newcaptcha' ); ?></a>
+						</p>
+						<p><img class="cyclos-captcha" alt='captcha' style='display:none'></p>
+					<?php endif; ?>
+
 				<?php endif; ?>
+
 				<p><input type='submit' value=<?php cyclos_loginform_label( 'forgot_submit' ); ?>></p>
 				<p><a class="cyclos-forgot-cancel" href='#'><?php cyclos_loginform_label( 'forgot_cancel' ); ?></a></p>
+
 			</form>
+
 		<?php endif; ?>
 
 		<form class='cyclos-login-form' action='#' method='post'>
@@ -44,11 +109,7 @@
 			<p><input placeholder="<?php cyclos_loginform_label( 'password' ); ?>" name='password' type='password' autocomplete="current-password" required></p>
 			<p><input type='submit' value="<?php cyclos_loginform_label( 'submit' ); ?>"></p>
 			<?php if ( $cyclos_is_forgot_password_enabled ) : ?>
-				<?php if ( empty( $cyclos_forgot_password_url ) ) : ?>
-					<p><a class="cyclos-forgot-link" href='#'><?php cyclos_loginform_label( 'forgot_link' ); ?></a></p>
-				<?php else : ?>
-					<p><a href="<?php echo esc_attr( $cyclos_forgot_password_url ); ?>"><?php cyclos_loginform_label( 'forgot_link' ); ?></a></p>
-				<?php endif; ?>
+				<p><a class="cyclos-forgot-link" href='#'><?php cyclos_loginform_label( 'forgot_link' ); ?></a></p>
 			<?php endif; ?>
 		</form>
 

--- a/templates/login-form.php
+++ b/templates/login-form.php
@@ -8,6 +8,7 @@
  * Available variables:
  * $cyclos_is_forgot_password_enabled indicates whether the functionality to recover a forgotten password is enabled in Cyclos.
  * $cyclos_is_captcha_enabled indicates whether Cyclos requires a captcha to request a forgotten password reset.
+ * $cyclos_forgot_password_url contains the Cyclos URL to request a forgotten password reset, or empty string if the plugin should handle this (for older Cyclos versions).
  * $cyclos_return_to contains the Cyclos request parameter indicating where to go within Cyclos after logging in. Can be empty.
  * $cyclos_error contains the error message in case of a severe error with the Cyclos server, for example if the server can not be reached. Can be empty.
  *
@@ -21,7 +22,8 @@
 
 	<?php if ( empty( $cyclos_error ) ) : ?>
 
-		<?php if ( $cyclos_is_forgot_password_enabled ) : ?>
+		<?php // For older Cyclos versions, we can handle the forgot password request here. Indicated by an empty forgot-password-url. ?>
+		<?php if ( $cyclos_is_forgot_password_enabled && empty( $cyclos_forgot_password_url ) ) : ?>
 			<form class='cyclos-forgotpassword-form' action='#' method='post' style='display:none'>
 				<p><input placeholder="<?php cyclos_loginform_label( 'forgot_principal' ); ?>" name='principal' type='text' autocomplete="username" required></p>
 				<?php if ( $cyclos_is_captcha_enabled ) : ?>
@@ -42,7 +44,11 @@
 			<p><input placeholder="<?php cyclos_loginform_label( 'password' ); ?>" name='password' type='password' autocomplete="current-password" required></p>
 			<p><input type='submit' value="<?php cyclos_loginform_label( 'submit' ); ?>"></p>
 			<?php if ( $cyclos_is_forgot_password_enabled ) : ?>
-				<p><a class="cyclos-forgot-link" href='#'><?php cyclos_loginform_label( 'forgot_link' ); ?></a></p>
+				<?php if ( empty( $cyclos_forgot_password_url ) ) : ?>
+					<p><a class="cyclos-forgot-link" href='#'><?php cyclos_loginform_label( 'forgot_link' ); ?></a></p>
+				<?php else : ?>
+					<p><a href="<?php echo esc_attr( $cyclos_forgot_password_url ); ?>"><?php cyclos_loginform_label( 'forgot_link' ); ?></a></p>
+				<?php endif; ?>
 			<?php endif; ?>
 		</form>
 


### PR DESCRIPTION
Implementing the new forgot password wizard, for WP sites connecting to a Cyclos server with version 4.13 or up, according to issue #3. See the issue for several considerations.