### PR TITLE
Issue 23: implement Google reCAPTCHA v2

### DIFF
--- a/app/Services/CyclosAPI.php
+++ b/app/Services/CyclosAPI.php
@@ -309,7 +309,7 @@ class CyclosAPI {
 		} else {
 			$sent_to = $cyclos_response->sentTo; // phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			if ( is_array( $sent_to ) && count( $sent_to ) > 0 ) {
-				$success_message = __( 'A verification code has been sent to ', 'cyclos' ) . $sent_to[0];
+				$success_message = __( 'A verification code has been sent to', 'cyclos' ) . ' ' . $sent_to[0];
 			} else {
 				$error_message = __( 'Something went wrong while trying to send you the verification code. Please contact the administration.', 'cyclos' );
 			}

--- a/app/Services/CyclosAPI.php
+++ b/app/Services/CyclosAPI.php
@@ -172,6 +172,8 @@ class CyclosAPI {
 	 *
 	 * @return array {
 	 *     @type boolean $is_forgot_password_enabled  Whether the forgotten password functionality is enabled in Cyclos or not.
+	 *     @type string $captcha_provider             The captcha provider as configured in Cyclos ('internal' or 'recaptchaV2'), or 'disabled' if no captcha is configured.
+	 *     @type string $recaptchav2_sitekey          The site key for Google recaptcha V2 if this is used as the captcha provider, or empty string if not.
 	 *     @type boolean $is_captcha_enabled          Whether the captcha functionality is enabled in Cyclos or not.
 	 *     @type boolean $has_complex_forgot_password Whether the current Cyclos version uses a more complex forgot password wizard.
 	 *     @type Array $forgot_password_mediums       List of mediums the user can choose to receive the forgot password verification code.
@@ -195,9 +197,13 @@ class CyclosAPI {
 		// The password type must be manual and there must be a medium to reset it. Otherwise we can not do a forgotten password request.
 		$login_pw_mode        = $cyclos_response->loginPasswordInput->mode ?? '';
 		$is_forgot_pw_allowed = ( 'manual' === $login_pw_mode ) && ! empty( $cyclos_response->forgotPasswordMediums );
+		$captcha_provider     = $cyclos_response->forgotPasswordCaptchaInput->provider ?? $cyclos_response->forgotPasswordCaptchaProvider ?? 'disabled';
+		$is_captcha_enabled   = ( 'internal' === $captcha_provider );
 		return array(
 			'is_forgot_password_enabled'  => $is_forgot_pw_allowed,
-			'is_captcha_enabled'          => isset( $cyclos_response->forgotPasswordCaptchaProvider ),
+			'captcha_provider'            => $captcha_provider,
+			'recaptchav2_sitekey'         => $cyclos_response->forgotPasswordCaptchaInput->recaptchaKey ?? '',
+			'is_captcha_enabled'          => $is_captcha_enabled,
 			'has_complex_forgot_password' => isset( $cyclos_response->identityProviders ),
 			'forgot_password_mediums'     => $cyclos_response->forgotPasswordMediums,
 		);

--- a/templates/login-form.php
+++ b/templates/login-form.php
@@ -7,7 +7,8 @@
  *
  * Available variables:
  * $cyclos_is_forgot_password_enabled indicates whether the functionality to recover a forgotten password is enabled in Cyclos.
- * $cyclos_is_captcha_enabled indicates whether Cyclos requires a captcha to request a forgotten password reset.
+ * $cyclos_is_captcha_enabled indicates whether Cyclos requires an internal captcha to request a forgotten password reset. Deprecated as from Cyclos 4.15. Use the new $cyclos_captcha_provider instead.
+ * $cyclos_captcha_provider indicates the captcha mechanism as from Cyclos 4.15. Can be either: disabled, internal, or recaptchaV2.
  * $cyclos_use_forgot_password_wizard whether we should handle forgotten password requests via a wizard, or via a simple request (for older Cyclos versions).
  * $cyclos_forgot_password_mediums contains an array of the mediums the user can choose to receive the confirmation key or code. Empty when forgot password is disabled.
  * $cyclos_return_to contains the Cyclos request parameter indicating where to go within Cyclos after logging in. Can be empty.
@@ -38,12 +39,16 @@
 
 						<p><input placeholder="<?php cyclos_loginform_label( 'forgot_principal' ); ?>" name='principal' type='text' autocomplete="username"></p>
 
-						<?php if ( $cyclos_is_captcha_enabled ) : ?>
+						<?php if ( 'internal' === $cyclos_captcha_provider ) : ?>
 							<p class="cyclos-line">
 								<input placeholder="<?php cyclos_loginform_label( 'forgot_captcha' ); ?>" name='captcha' type='text'>
 								<a class="cyclos-newcaptcha" href='#'><?php cyclos_loginform_label( 'forgot_newcaptcha' ); ?></a>
 							</p>
 							<p><img class="cyclos-captcha" alt='captcha' style='display:none'></p>
+						<?php endif; ?>
+
+						<?php if ( 'recaptchaV2' === $cyclos_captcha_provider ) : ?>
+							<div class="cyclos-google-recaptchav2"></div>
 						<?php endif; ?>
 
 						<?php if ( count( $cyclos_forgot_password_mediums ) > 1 ) : ?>


### PR DESCRIPTION
This PR solves issue #23: The forgot-password functionality in the plugin now works both with the new Cyclos 4.15 (recaptchaV2 or internal captcha provider) and older Cyclos versions (internal captcha only). Or disabled captcha of course.